### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Please note that we are not actively providing support on Stack Overflow. If you
 
 ## 🚀 Installation and upgrading
 
-CLI and manual setup procedures are fully detailed in the [official docs](https://docs.stimulusreflex.com/setup).
+CLI and manual setup procedures are fully detailed in the [official docs](https://docs.stimulusreflex.com/hello-world/setup.html).
 
 ### Rubygem
 


### PR DESCRIPTION
The link to the setup section of the official docs was giving a 404.

# Type of PR (feature, enhancement, bug fix, etc.)

Documentation.

## Description

Fix broken link in README.md

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
